### PR TITLE
Add fallback to log OTP to console when Mailgun API key is omitted

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,9 +27,9 @@ logging.basicConfig(
 load_dotenv()
 
 DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
-MAILGUN_API_KEY = os.environ["MAILGUN_API_KEY"]
-MAILGUN_DOMAIN = os.environ["MAILGUN_DOMAIN"]
-MAILGUN_FROM = os.environ["MAILGUN_FROM"]
+MAILGUN_API_KEY = os.environ.get("MAILGUN_API_KEY")
+MAILGUN_DOMAIN = os.environ.get("MAILGUN_DOMAIN")
+MAILGUN_FROM = os.environ.get("MAILGUN_FROM")
 VERIFIED_ROLE_NAME = os.environ["VERIFIED_ROLE_NAME"]
 ALLOWED_DOMAINS = [d.strip().lower() for d in os.environ["ALLOWED_EMAIL_DOMAINS"].split(",")]
 
@@ -93,6 +93,12 @@ def valid_email_domain(email):
     return domain in ALLOWED_DOMAINS
 
 def send_email_otp(to_email, code):
+    if not MAILGUN_API_KEY:
+        print(f"OTP for {to_email}: {code}")
+        class MockResponse:
+            status_code = 200
+        return MockResponse()
+
     return requests.post(
         f"https://api.mailgun.net/v3/{MAILGUN_DOMAIN}/messages",
         auth=("api", MAILGUN_API_KEY),

--- a/bot.py
+++ b/bot.py
@@ -384,5 +384,8 @@ async def import_db(interaction: discord.Interaction, file: discord.Attachment):
 async def on_ready():
     await tree.sync()
     print(f"Logged in as {bot.user}")
+    if not MAILGUN_API_KEY:
+        logging.warning("No Mailgun API key provided. OTPs will be logged to the console.")
+        print("WARNING: No Mailgun API key provided. OTPs will be logged to the console.")
 
 bot.run(DISCORD_TOKEN)

--- a/sample_env
+++ b/sample_env
@@ -1,6 +1,6 @@
 # Modify the values and save this file as .env
 DISCORD_TOKEN=YOUR_BOT_TOKEN
-MAILGUN_API_KEY=YOUR_MAILGUN_API_KEY
+MAILGUN_API_KEY=
 MAILGUN_DOMAIN=yourdomain.com
 MAILGUN_FROM=Verification Bot <verify@yourdomain.com>
 VERIFIED_ROLE_NAME=verified


### PR DESCRIPTION
Hey! @LaughableHammer 👋

This PR addresses the issue of needing a valid Mailgun API key during local development or testing. 

Currently, the bot throws an error on startup if the `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`, or `MAILGUN_FROM` environment variables are missing. It also tries to reach out to the Mailgun API when generating an OTP.

**Changes made:**
- Made the Mailgun-related environment variables optional via `.get()`, avoiding startup crashes when they aren't provided.
- Updated `send_email_otp()` to check if the Mailgun API key is present. 
- If the API key is missing, it now gracefully falls back to printing the generated OTP to the console and returns a mock 200 success response. 

This lets us spin up the bot and verify the entire OTP flow locally without actually sending emails, while keeping the production behavior completely unchanged when the keys are present. 

Let me know if you'd like any adjustments!

ref issue #21 