### PR TITLE
Small fix: Check the column names of import CSVs

### DIFF
--- a/export.py
+++ b/export.py
@@ -32,6 +32,10 @@ def import_csv_to_db(conn, csv_contents: str) -> tuple[bool, str]:
     try:
         reader = csv.DictReader(io.StringIO(csv_contents))
 
+        if set(reader.fieldnames) != set(UserSchema.model_fields.keys()):
+            return False, ("Validation Error: CSV column names are incorrect, "
+                           f"should be `{set(UserSchema.model_fields.keys())}`.")
+
         for line_num, row in enumerate(
             reader, start=2
         ):  # start=2 for CSV row numbering


### PR DESCRIPTION
This PR changes the import logic slightly so that single-line invalid files don't pass validation.

This means that all 4 columns are required now, I don't think that will be an issue though.