### PR TITLE
Allow verifying by clicking a button rather than running /verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,36 @@ It is designed to be as simple as possible to implement in any UNSW society as q
 See images of the verification process in `images` folder.
 
 ## Setup
-1. Create a server role called `verified` which grants users access to server channels.
-2. Create a text channel called `verification-logs` 
-3. Create a `verify` text channel
-4. Invite the discord bot to the server and grant requested permissions [secso.cc/verificationbot](http://secso.cc/verificationbot)
+1. Create a server role called `verified` which grants users access to server channels
+2. Create an admin-only `#verification-logs` text channel
+3. Create a `#verify` text channel
+4. Invite the discord bot to the server and grant requested permissions ([secso.cc/verificationbot](http://secso.cc/verificationbot))
+5. Run `/send-verify-button` in `#verify`
 5. Profit!?
+
+Once these steps are complete users will be able to verify by clicking the `Verify Email` button.
 
 ### Important notes:
 The bot user role must be higher in the hierarchy than the `verified` role in server settings. \
 The `verification-logs` channel should only be accessible by a few trusted members of the society's executive team to protect user privacy. \
 The `verify` channel should be the only channel accessible to an unverified discord user. It doesn't need to be called 'verify'. \
-Also, remove all permissions besides `Use Application Commands` for `@everyone`.
+Also, remove all permissions from `@everyone`. They will still be able to use the verification button.
 
-### Backups
-SecSoc does not guarantee the availability of backups for all societies so we reccommend regularly utilising the /export (admin only) command and maintain backups for your own society. If issues arise, contact `projects@unswsecurity.com` or for general problems, raise an issue on this GitHub repository.
+## Backups
+SecSoc does not guarantee the availability of backups for all societies so we reccommend regularly utilising the `/export` (admin only) command and maintain backups for your own society. If issues arise, contact `projects@unswsecurity.com` or for general problems, raise an issue on this GitHub repository.
 
-### Migration
-In order to migrate existing verified discord members to this verification bot, you will need to construct an SQLite3 database with columns `discord_id` as the primary key and `email` as the minimum requirement. Optionally, you may also add a `verified` column which stores values 1 or 0 indicating whether this person is actively verified on the server and also a `verified_at` column which stores time of verification in unix time. If `verified` is not specified, the column is created and its value defaults to 1 (meaning verified) and if `verified_at` is omitted then it is left as `NULL`.
-You may find it useful to utilise a Python script to migrate your current configuration into a valid database and feel free to contact `projects@unswsecurity.com` for help.
+## Migration
+In order to migrate existing verified discord members to this verification bot, you will need to `/import` a CSV in the following format:
+
+```csv
+discord_id,email,verified,verified_at
+123456789123456789,person1@ad.unsw.edu.au,1,
+234567892345678923,person2@ad.unsw.edu.au,1,
+```
+
+Every row must contain at least a `discord_id` and `email`. If `verified` is omitted it will default to 0 (false). Optionally, you may also add an informational `verified_at` value which stores the time of verification in unix seconds.
+
+You may find it useful to utilise a Python script to migrate your current configuration to a CSV. Feel free to contact `projects@unswsecurity.com` for help.
 
 ## Why this bot
 At the time of writing, this bot provides many benefits over other bots with the same aim:

--- a/bot.py
+++ b/bot.py
@@ -332,7 +332,7 @@ class OTPView(discord.ui.View):
         await interaction.response.send_modal(OTPModal())
 
 
-class VerifyView(discord.ui.View):
+class VerifyButtonView(discord.ui.View):
     @discord.ui.button(label="Verify Email", style=discord.ButtonStyle.success)
     async def verify_button(
         self, interaction: discord.Interaction, button: discord.ui.Button
@@ -445,12 +445,21 @@ async def import_db(interaction: discord.Interaction, file: discord.Attachment):
     description="Send a verification button to this channel",
 )
 @app_commands.default_permissions(administrator=True)
+@app_commands.checks.bot_has_permissions(send_messages=True)
 async def send_verify_button(interaction: discord.Interaction):
     await interaction.response.defer(ephemeral=True)
-    await interaction.channel.send(
-        "Click here to verify your email.", view=VerifyView()
-    )
-    await interaction.followup.send("Verification button sent.", ephemeral=True)
+    try:
+        await interaction.channel.send(
+            "Click here to verify your email.", view=VerifyButtonView()
+        )
+    except discord.Forbidden:
+        await interaction.followup.send(
+            "Failed to send verification button. "
+            "Does the bot have permissions to send messages in this channel?",
+            ephemeral=True
+        )
+    else:
+        await interaction.followup.send("Verification button sent.", ephemeral=True)
 
 
 # Runs once on initial startup

--- a/bot.py
+++ b/bot.py
@@ -333,7 +333,10 @@ class OTPView(discord.ui.View):
 
 
 class VerifyButtonView(discord.ui.View):
-    @discord.ui.button(label="Verify Email", style=discord.ButtonStyle.success)
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    @discord.ui.button(label="Verify Email", style=discord.ButtonStyle.success, custom_id="verify-button")
     async def verify_button(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
@@ -485,6 +488,7 @@ async def setup_hook():
 @bot.event
 async def on_ready():
     print(f"Logged in as {bot.user}")
+
     if not config.MAILGUN_API_KEY:
         logging.warning(
             "No Mailgun API key provided. OTPs will be logged to the console."
@@ -492,6 +496,9 @@ async def on_ready():
         print(
             "WARNING: No Mailgun API key provided. OTPs will be logged to the console."
         )
+
+    # Register the button view so it keeps working after a restart
+    bot.add_view(VerifyButtonView())
 
 
 bot.run(config.DISCORD_TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -332,6 +332,14 @@ class OTPView(discord.ui.View):
         await interaction.response.send_modal(OTPModal())
 
 
+class VerifyView(discord.ui.View):
+    @discord.ui.button(label="Verify Email", style=discord.ButtonStyle.success)
+    async def verify_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
+        await interaction.response.send_modal(EmailModal())
+
+
 # TODO: Remove this function since it is redundant.
 def get_guild_db_path(guild: discord.Guild) -> str:
     return f"{safe_guild_filename(guild)}"
@@ -430,6 +438,19 @@ async def import_db(interaction: discord.Interaction, file: discord.Attachment):
             logging.warning(
                 f"Database import for guild {interaction.guild} failed: {message}"
             )
+
+
+@bot.tree.command(
+    name="send-verify-button",
+    description="Send a verification button to this channel",
+)
+@app_commands.default_permissions(administrator=True)
+async def send_verify_button(interaction: discord.Interaction):
+    await interaction.response.defer(ephemeral=True)
+    await interaction.channel.send(
+        "Click here to verify your email.", view=VerifyView()
+    )
+    await interaction.followup.send("Verification button sent.", ephemeral=True)
 
 
 # Runs once on initial startup

--- a/bot.py
+++ b/bot.py
@@ -90,7 +90,7 @@ def get_commands_hash() -> str:
     return hashlib.md5(json.dumps(commands, sort_keys=True).encode()).hexdigest()
 
 
-# create a popup in discord upon /verify invocation
+# modal for the user to enter their email
 class EmailModal(discord.ui.Modal, title="Email Verification"):
     email = discord.ui.TextInput(label="Enter your UNSW email address", required=True)
 
@@ -229,7 +229,7 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
 
         if not record:
             await interaction.response.send_message(
-                "No active verification. Use /verify again.", ephemeral=True
+                "No active verification. Please click the `Verify Email` button again.", ephemeral=True
             )
             return
 
@@ -357,13 +357,6 @@ def close_guild_db(guild: discord.Guild):
 
 
 # ---------------- COMMANDS ----------------
-# main command
-@tree.command(name="verify", description="Verify your email")
-@app_commands.guild_only()
-async def verify(interaction: discord.Interaction):
-    await interaction.response.send_modal(EmailModal())
-
-
 @bot.tree.command(name="export", description="Download the verification database file")
 @app_commands.default_permissions(administrator=True)  # need to be admin
 @app_commands.checks.has_permissions(administrator=True)


### PR DESCRIPTION
Adds a command, `/send-verify-button`, allowing admins to send a verification button in a channel. When clicked, this button opens the verification modal, as if the user ran /verify. This allows users to verify without needing the send messages permission

<img width="365" height="99" alt="image" src="https://github.com/user-attachments/assets/a813c854-b5fa-4eca-869b-fb1629080b83" />

Closes #24 