### PR TITLE
Move guild databases and backups into individual directory

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ from zoneinfo import ZoneInfo
 
 import config
 from otp import generate_otp, send_email_otp, valid_email_domain
-from utils import log_admin, safe_guild_filename, safe_guild_name
+from utils import log_admin, get_guild_db_path, get_guild_dir, save_guild_info
 
 os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
@@ -40,7 +40,8 @@ def get_guild_db(guild: discord.Guild):
     if guild.id in db_connections:
         return db_connections[guild.id]
 
-    path = safe_guild_filename(guild)
+    path = get_guild_db_path(guild)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     conn = sqlite3.connect(path)
     c = conn.cursor()
     c.execute("""
@@ -54,7 +55,10 @@ def get_guild_db(guild: discord.Guild):
     """)
     conn.commit()
     db_connections[guild.id] = conn
-    logging.info(f"created database for guild {guild.id}")
+    logging.info(f"loaded or created database for guild {guild.id}")
+
+    save_guild_info(guild)
+
     return conn
 
 
@@ -332,11 +336,6 @@ class OTPView(discord.ui.View):
         await interaction.response.send_modal(OTPModal())
 
 
-# TODO: Remove this function since it is redundant.
-def get_guild_db_path(guild: discord.Guild) -> str:
-    return f"{safe_guild_filename(guild)}"
-
-
 def close_guild_db(guild: discord.Guild):
     logging.info(f"closing guild db connection for {guild}")
     gid = guild.id
@@ -387,13 +386,11 @@ async def import_db(interaction: discord.Interaction, file: discord.Attachment):
     conn = get_guild_db(interaction.guild)  # type: ignore
 
     try:
-        guild_folder = safe_guild_name(interaction.guild)  # type: ignore
-        backup_dir = os.path.join("guild_dbs", "backups", guild_folder)
+        backup_dir = os.path.join(get_guild_dir(interaction.guild), "backups")
         os.makedirs(backup_dir, exist_ok=True)
 
         timestamp = int(time.time())
-        guild_name = safe_guild_name(interaction.guild)  # type: ignore
-        backup_filename = f"{guild_name}_{interaction.guild.id}_{timestamp}.db.backup"  # type: ignore
+        backup_filename = f"{timestamp}.db.backup"
         backup_path = os.path.join(backup_dir, backup_filename)
 
         with sqlite3.connect(backup_path) as backup_dest_conn:

--- a/utils.py
+++ b/utils.py
@@ -1,17 +1,24 @@
 import os
-import re
 import sys
 import discord
 import config
 
 
-def safe_guild_name(guild: discord.Guild) -> str:
-    return re.sub(r"[^a-zA-Z0-9_-]", "_", guild.name)
+def get_guild_dir(guild: discord.Guild):
+    return os.path.join(config.DB_FOLDER, str(guild.id))
 
 
-# TODO: Don't prepend DB_FOLDER here, do that later or rename function
-def safe_guild_filename(guild: discord.Guild):
-    return os.path.join(config.DB_FOLDER, f"{safe_guild_name(guild)}_{guild.id}.db")
+def get_guild_db_path(guild: discord.Guild):
+    return os.path.join(get_guild_dir(guild), "database.db")
+
+
+# store the human-readable guild name in its data directory
+def save_guild_info(guild: discord.Guild) -> None:
+    guild_dir = get_guild_dir(guild)
+    os.makedirs(guild_dir, exist_ok=True)
+    info_file = os.path.join(guild_dir, "guild_name.txt")
+    with open(info_file, "w") as f:
+        f.write(guild.name)
 
 
 async def log_admin(message, guild):


### PR DESCRIPTION
Moves all data for a given guild into a single directory:

e.g.
```
guild_dbs/
└── 1483757351168245802
    ├── backups
    │   └── 1778092672.db.backup
    ├── database.db
    └── guild_name.txt
```

This prevents an issue where renaming a server would cause the bot to lose the database for that server.

Closes #17