### PR TITLE
Allow per-server configuration for verified roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ It is designed to be as simple as possible to implement in any UNSW society as q
 See images of the verification process in `images` folder.
 
 ## Setup
-1. Create a server role called `verified` which grants users access to server channels
+1. Invite the discord bot to the server and grant requested permissions ([secso.cc/verificationbot](http://secso.cc/verificationbot))
 2. Create an admin-only `#verification-logs` text channel
-3. Create a `#verify` text channel
-4. Invite the discord bot to the server and grant requested permissions ([secso.cc/verificationbot](http://secso.cc/verificationbot))
-5. Run `/send-verify-button` in `#verify`
-5. Profit!?
+3. Create a server role called `verified` which grants users access to server channels
+4. Run `/set-verified-role @verified`
+5. Create a `#verify` text channel
+6. Run `/send-verify-button` in `#verify`
+7. Profit!?
 
 Once these steps are complete users will be able to verify by clicking the `Verify Email` button.
 
@@ -37,6 +38,9 @@ discord_id,email,verified,verified_at
 Every row must contain at least a `discord_id` and `email`. If `verified` is omitted it will default to 0 (false). Optionally, you may also add an informational `verified_at` value which stores the time of verification in unix seconds.
 
 You may find it useful to utilise a Python script to migrate your current configuration to a CSV. Feel free to contact `projects@unswsecurity.com` for help.
+
+### Using an existing role
+If you already have a role for verified users, you don't have to create a new one. You can set that role as the one used by the bot with `/set-verified-role <role>`.
 
 ## Why this bot
 At the time of writing, this bot provides many benefits over other bots with the same aim:

--- a/src/bot.py
+++ b/src/bot.py
@@ -54,6 +54,12 @@ def get_guild_db(guild: discord.Guild):
             CHECK ((verified_at IS NULL) OR verified) -- verified_at implies verified
         ) STRICT
     """)
+    c.execute("""
+        CREATE TABLE IF NOT EXISTS config (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        ) STRICT
+    """)
     conn.commit()
     db_connections[guild.id] = conn
     logging.info(f"loaded or created database for guild {guild.id}")
@@ -61,6 +67,33 @@ def get_guild_db(guild: discord.Guild):
     save_guild_info(guild)
 
     return conn
+
+
+def get_verified_role(guild: discord.Guild) -> discord.Role | None:
+    conn = get_guild_db(guild)
+    c = conn.cursor()
+    c.execute("SELECT value FROM config WHERE key = 'verified_role_id'")
+    row = c.fetchone()
+
+    if row is None:
+        return None
+
+    role_id = int(row[0])
+    return guild.get_role(role_id)
+
+
+def set_verified_role(guild: discord.Guild, role: discord.Role) -> None:
+    conn = get_guild_db(guild)
+    c = conn.cursor()
+    c.execute(
+        """
+        INSERT INTO config (key, value)
+        VALUES ('verified_role_id', ?)
+        ON CONFLICT(key) DO UPDATE SET value=excluded.value
+    """,
+        (str(role.id),),
+    )
+    conn.commit()
 
 
 # Active OTP dictionary
@@ -100,22 +133,24 @@ class EmailModal(discord.ui.Modal, title="Email Verification"):
     email = discord.ui.TextInput(label="Enter your UNSW email address", required=True)
 
     async def on_submit(self, interaction: discord.Interaction):
+        assert interaction.guild is not None
+
         user_id = interaction.user.id
         email = self.email.value.strip().lower()
 
         logging.info(f"{interaction.user} is attempting to verify")
 
         # Check DB if already verified
-        conn = get_guild_db(interaction.guild)  # type: ignore Bot can only run in a guild
+        conn = get_guild_db(interaction.guild)
         c = conn.cursor()
         c.execute("SELECT verified, email FROM users WHERE discord_id=?", (user_id,))
         row = c.fetchone()
 
         if row and row[0] == 1:
             guild = interaction.guild
-            member = guild.get_member(user_id)  # type: ignore Bot can only run in a guild
+            member = guild.get_member(user_id)
             bot_member = guild.get_member(bot.user.id)  # type: ignore
-            role = discord.utils.get(guild.roles, name=config.VERIFIED_ROLE_NAME)  # type: ignore
+            role = get_verified_role(guild)
 
             if not member or not role or not bot_member:
                 await interaction.response.send_message(
@@ -132,7 +167,7 @@ class EmailModal(discord.ui.Modal, title="Email Verification"):
                 return
 
             # Role missing — try to restore it
-            if not guild.me.guild_permissions.manage_roles:  # type: ignore
+            if not guild.me.guild_permissions.manage_roles:
                 await interaction.response.send_message(
                     "⚠️ You're verified but I don't have permission to restore your role.",
                     ephemeral=True,
@@ -175,7 +210,7 @@ class EmailModal(discord.ui.Modal, title="Email Verification"):
             return
 
         now = time.time()
-        key = (interaction.guild.id, user_id)  # type: ignore
+        key = (interaction.guild.id, user_id)
         record = pending_verifications.get(key)
 
         if record and now - record["last_sent"] < config.OTP_RESEND_COOLDOWN:
@@ -186,7 +221,7 @@ class EmailModal(discord.ui.Modal, title="Email Verification"):
             return
 
         code = generate_otp()
-        key = (interaction.guild.id, user_id)  # type: ignore
+        key = (interaction.guild.id, user_id)
         pending_verifications[key] = {
             "code": code,
             "expires": now + config.OTP_EXPIRY_SECONDS,
@@ -263,7 +298,7 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
             )
             return
 
-        role = discord.utils.get(guild.roles, name=config.VERIFIED_ROLE_NAME)
+        role = get_verified_role(guild)
 
         if not role:
             await interaction.response.send_message(
@@ -299,10 +334,6 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
                 "❌ Discord API error. Try again later.", ephemeral=True
             )
             return
-
-        role = discord.utils.get(interaction.guild.roles, name=config.VERIFIED_ROLE_NAME)  # type: ignore
-        if role:
-            await interaction.user.add_roles(role)  # type: ignore
 
         del pending_verifications[key]
 
@@ -428,6 +459,46 @@ async def send_verify_button(interaction: discord.Interaction):
         )
     else:
         await interaction.followup.send("Verification button sent.", ephemeral=True)
+
+
+@bot.tree.command(
+    name="set-verified-role",
+    description="Set the role to assign to verified members",
+)
+@app_commands.default_permissions(administrator=True)
+@app_commands.checks.has_permissions(administrator=True)
+@app_commands.guild_only()
+async def set_verified_role_cmd(interaction: discord.Interaction, role: discord.Role):
+    assert interaction.guild is not None
+
+    await interaction.response.defer(ephemeral=True)
+
+    bot_member = interaction.guild.get_member(bot.user.id)  # type: ignore
+    if role >= bot_member.top_role:  # type: ignore
+        await interaction.followup.send(
+            "❌ That role is not lower in the role hierarchy than the bot's top role.",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        set_verified_role(interaction.guild, role)
+        await interaction.followup.send(
+            f"✅ Verified role set to {role.mention}",
+            ephemeral=True,
+            allowed_mentions=discord.AllowedMentions(roles=False),
+        )
+        await log_admin(
+            f"🔧 {interaction.user} set verified role to {role.mention}",
+            interaction.guild,
+            allowed_mentions=discord.AllowedMentions(roles=False),
+        )
+    except Exception as e:
+        logging.error(f"Failed to set verified role: {e}")
+        await interaction.followup.send(
+            "❌ Failed to set verified role.",
+            ephemeral=True,
+        )
 
 
 # Runs once on initial startup

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,6 @@ DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
 MAILGUN_API_KEY = os.environ.get("MAILGUN_API_KEY")
 MAILGUN_DOMAIN = os.environ.get("MAILGUN_DOMAIN")
 MAILGUN_FROM = os.environ.get("MAILGUN_FROM")
-VERIFIED_ROLE_NAME = os.environ["VERIFIED_ROLE_NAME"]
 ALLOWED_DOMAINS = [d.strip().lower() for d in os.environ["ALLOWED_EMAIL_DOMAINS"].split(",")]
 
 OTP_EXPIRY_SECONDS = 600

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,7 +23,7 @@ def save_guild_info(guild: discord.Guild) -> None:
         f.write(guild.name)
 
 
-async def log_admin(message, guild):
+async def log_admin(message, guild, **kwargs):
     channel = discord.utils.get(guild.text_channels, name="verification-logs")
 
     if channel is None:
@@ -34,4 +34,4 @@ async def log_admin(message, guild):
         print(f"Missing permission to send messages in #{channel.name}", file=sys.stderr)
         return
 
-    await channel.send(message)
+    await channel.send(message, **kwargs)


### PR DESCRIPTION
Closes #36. The config is stored in a new table. This table is not included in exports/imports.