### PR TITLE
Refactor bot.py

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 import logging
 import os
 import sqlite3
@@ -16,113 +14,102 @@ import config
 import logs
 from export import export_db_to_csv, import_csv_to_db
 from otp import generate_otp, match_email, redact_email, send_email_otp, valid_email_domain
-from utils import get_guild_db_path, get_guild_dir, log_admin, save_guild_info
+from utils import (
+    get_commands_hash,
+    get_guild_db,
+    get_guild_dir,
+    get_verified_role,
+    log_admin,
+    set_verified_role,
+)
 
 # setup Logfire
 logs.init()
 
 os.makedirs(config.DB_DIR, exist_ok=True)
 
-# one connection per guild
-db_connections = {}
-
 # what events we want our bot to be aware of
 intents = discord.Intents.default()
 intents.members = True
 
 bot = commands.Bot(command_prefix="!", intents=intents)
-tree = bot.tree
-
-
-def get_guild_db(guild: discord.Guild):
-    if guild.id in db_connections:
-        return db_connections[guild.id]
-
-    path = get_guild_db_path(guild)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    conn = sqlite3.connect(path)
-    c = conn.cursor()
-    c.execute("""
-        CREATE TABLE IF NOT EXISTS users (
-            discord_id INTEGER PRIMARY KEY,
-            email TEXT,
-            verified INTEGER NOT NULL CHECK (verified IN (0, 1)) DEFAULT 0,
-            verified_at INTEGER CHECK (verified_at > 0),
-            CHECK ((verified_at IS NULL) OR verified) -- verified_at implies verified
-        ) STRICT
-    """)
-    c.execute("""
-        CREATE TABLE IF NOT EXISTS config (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL
-        ) STRICT
-    """)
-    conn.commit()
-    db_connections[guild.id] = conn
-    logging.info(f"loaded or created database for guild {guild.id}")
-
-    save_guild_info(guild)
-
-    return conn
-
-
-def get_verified_role(guild: discord.Guild) -> discord.Role | None:
-    conn = get_guild_db(guild)
-    c = conn.cursor()
-    c.execute("SELECT value FROM config WHERE key = 'verified_role_id'")
-    row = c.fetchone()
-
-    if row is None:
-        return None
-
-    role_id = int(row[0])
-    return guild.get_role(role_id)
-
-
-def set_verified_role(guild: discord.Guild, role: discord.Role) -> None:
-    conn = get_guild_db(guild)
-    c = conn.cursor()
-    c.execute(
-        """
-        INSERT INTO config (key, value)
-        VALUES ('verified_role_id', ?)
-        ON CONFLICT(key) DO UPDATE SET value=excluded.value
-    """,
-        (str(role.id),),
-    )
-    conn.commit()
-
 
 # Active OTP dictionary
-pending_verifications = {}
 # (guild_id, user_id): {code, expires, last_sent, email}
+pending_verifications = {}
 
 
-def get_commands_hash() -> str:
-    # Changes when a commands name or description, or its parameters' name or description changes
-    # Also changes if a parameter's mandatoriness changes
-    commands = sorted(
-        (
-            {
-                "name": c.name,
-                "description": c.description,  # type: ignore
-                "parameters": sorted(
-                    (
-                        {
-                            "name": p.name,
-                            "description": p.description,
-                            "required": p.required,
-                        }
-                        for p in c.parameters  # type: ignore
-                    ),
-                    key=lambda p: p["name"],
-                ),
-            }
-            for c in tree.get_commands()
-        ),
-        key=lambda c: c["name"],
-    )
-    return hashlib.md5(json.dumps(commands, sort_keys=True).encode()).hexdigest()
+def is_verified(member: discord.Member) -> bool:
+    # Check DB if already verified
+    conn = get_guild_db(member.guild)
+    c = conn.cursor()
+    c.execute("SELECT verified, email FROM users WHERE discord_id=?", (member.id,))
+    row = c.fetchone()
+    return row is not None and row[0] == 1
+
+
+async def grant_verified_role(interaction: discord.Interaction) -> str | None:
+    assert interaction.guild is not None
+    assert isinstance(interaction.user, discord.Member)
+
+    guild = interaction.guild
+    member = interaction.user
+
+    role = get_verified_role(guild)
+
+    if not role:
+        return "❌ Verified role not found. Contact an admin."
+
+    # permission check
+    if not guild.me.guild_permissions.manage_roles:
+        return "❌ Bot lacks **Manage Roles** permission. Contact an admin."
+
+    # role hierarchy check
+    if role >= guild.me.top_role:
+        await log_admin(
+            "❌ Bot cannot assign role: it is higher than or equal to the bot's top role.",
+            interaction.guild,
+        )
+        return (
+            "❌ Bot cannot assign the verified role because it is higher than"
+            " the bot's top role. Contact an admin."
+        )
+
+    try:
+        await member.add_roles(role, reason="User completed email verification")
+    except discord.Forbidden:
+        return "❌ Permission error while assigning role. Contact an admin."
+    except discord.HTTPException:
+        return "❌ Discord API error. Try again later."
+
+    return None
+
+
+async def restore_verified_role(interaction: discord.Interaction) -> str:
+    assert interaction.guild is not None
+    assert isinstance(interaction.user, discord.Member)
+
+    guild = interaction.guild
+    member = interaction.user
+    role = get_verified_role(guild)
+
+    if not role:
+        await log_admin(
+            "❌ Bot is unable to check member roles",
+            interaction.guild,
+        )
+        return "⚠️ You are verified but I couldn't check roles."
+
+    # If they already have the role
+    if role in member.roles:
+        return "✅ You are already verified."
+
+    # Role missing - try to restore it
+    await log_admin(f"♻️ Restoring verified role for {interaction.user}", guild)
+    err = await grant_verified_role(interaction)
+    if err is not None:
+        return "🔁 You were already verified but I couldn't restore your role:\n" + err
+    return "🔁 You were already verified - I've restored your role."
 
 
 # modal for the user to enter their email
@@ -132,82 +119,15 @@ class EmailModal(discord.ui.Modal, title="Email Verification"):
     @logfire.instrument(extract_args=["interaction"])
     async def on_submit(self, interaction: discord.Interaction):
         assert interaction.guild is not None
+        assert isinstance(interaction.user, discord.Member)
 
-        user_id = interaction.user.id
         email = self.email.value.strip().lower()
 
         logging.info(f"{interaction.user} is attempting to verify")
 
-        # Check DB if already verified
-        conn = get_guild_db(interaction.guild)
-        c = conn.cursor()
-        c.execute("SELECT verified, email FROM users WHERE discord_id=?", (user_id,))
-        row = c.fetchone()
-
-        if row and row[0] == 1:
-            guild = interaction.guild
-            member = guild.get_member(user_id)
-            role = get_verified_role(guild)
-
-            if not member or not role:
-                await log_admin(
-                    "❌ Bot is unable to check member roles",
-                    interaction.guild,
-                )
-                await interaction.response.send_message(
-                    "⚠️ You are verified but I couldn't check roles.",
-                    ephemeral=True,
-                )
-                return
-
-            # If they already have the role
-            if role in member.roles:
-                await interaction.response.send_message(
-                    "✅ You are already verified.", ephemeral=True
-                )
-                return
-
-            # Role missing — try to restore it
-            if not guild.me.guild_permissions.manage_roles:
-                await log_admin(
-                    "❌ Bot doesn't have `Manage Roles` permission",
-                    interaction.guild,
-                )
-                await interaction.response.send_message(
-                    "⚠️ You're verified but I don't have permission to restore your role.",
-                    ephemeral=True,
-                )
-                return
-
-            if role >= guild.me.top_role:
-                await log_admin(
-                    "❌ Bot cannot assign role: it is higher than or equal to the bot's top role.",
-                    interaction.guild,
-                )
-                await interaction.response.send_message(
-                    "⚠️ You're verified but my role is too low to re-assign yours.",
-                    ephemeral=True,
-                )
-                return
-
-            try:
-                await member.add_roles(role, reason="Restoring verified role")
-                await interaction.response.send_message(
-                    "🔁 You were already verified — I've restored your role.",
-                    ephemeral=True,
-                )
-                await log_admin(f"♻️ Restored verified role for {interaction.user}", guild)
-            except discord.Forbidden:
-                await interaction.response.send_message(
-                    "⚠️ Verified in database but role restore failed due to permissions.",
-                    ephemeral=True,
-                )
-            except discord.HTTPException:
-                await interaction.response.send_message(
-                    "⚠️ Discord error while restoring role. Try again later.",
-                    ephemeral=True,
-                )
-
+        if is_verified(interaction.user):
+            msg = await restore_verified_role(interaction)
+            await interaction.response.send_message(msg, ephemeral=True)
             return
 
         if not match_email(email):
@@ -226,10 +146,11 @@ class EmailModal(discord.ui.Modal, title="Email Verification"):
             )
             return
 
-        now = time.time()
+        user_id = interaction.user.id
         key = (interaction.guild.id, user_id)
         record = pending_verifications.get(key)
 
+        now = time.time()
         if record and now - record["last_sent"] < config.OTP_RESEND_COOLDOWN:
             remaining = int(config.OTP_RESEND_COOLDOWN - (now - record["last_sent"]))
             await interaction.response.send_message(
@@ -269,8 +190,10 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
 
     @logfire.instrument(extract_args=["interaction"])
     async def on_submit(self, interaction: discord.Interaction):
+        assert interaction.guild is not None
+
         user_id = interaction.user.id
-        key = (interaction.guild.id, user_id)  # type: ignore
+        key = (interaction.guild.id, user_id)
         record = pending_verifications.get(key)
 
         if not record:
@@ -292,8 +215,8 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
             await log_admin(f"❌ Wrong OTP from {interaction.user}", interaction.guild)
             return
 
-        # Success — store in DB
-        conn = get_guild_db(interaction.guild)  # type: ignore
+        # Success - store in DB
+        conn = get_guild_db(interaction.guild)
         c = conn.cursor()
         c.execute(
             """
@@ -308,54 +231,9 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
         )
         conn.commit()
 
-        guild = interaction.guild
-        member = interaction.guild.get_member(interaction.user.id)  # type: ignore
-
-        if not guild or not member:
-            await interaction.response.send_message(
-                "❌ Verification failed (server state error).", ephemeral=True
-            )
-            return
-
-        role = get_verified_role(guild)
-
-        if not role:
-            await interaction.response.send_message(
-                "❌ Verified role not found. Contact an admin.", ephemeral=True
-            )
-            return
-
-        # permission check
-        if not guild.me.guild_permissions.manage_roles:
-            await interaction.response.send_message(
-                "❌ Bot lacks **Manage Roles** permission.", ephemeral=True
-            )
-            return
-
-        # role hierarchy check
-        if role >= guild.me.top_role:
-            await log_admin(
-                "❌ Bot cannot assign role: it is higher than or equal to the bot's top role.",
-                interaction.guild,
-            )
-            await interaction.response.send_message(
-                "❌ Bot cannot assign this role because it is higher than "
-                "or equal to the bot's top role.",
-                ephemeral=True,
-            )
-            return
-
-        try:
-            await member.add_roles(role, reason="User completed email verification")
-        except discord.Forbidden:
-            await interaction.response.send_message(
-                "❌ Permission error while assigning role.", ephemeral=True
-            )
-            return
-        except discord.HTTPException:
-            await interaction.response.send_message(
-                "❌ Discord API error. Try again later.", ephemeral=True
-            )
+        err = await grant_verified_role(interaction)
+        if err is not None:
+            await interaction.response.send_message(err, ephemeral=True)
             return
 
         del pending_verifications[key]
@@ -382,15 +260,14 @@ class VerifyButtonView(discord.ui.View):
         label="Verify Email", style=discord.ButtonStyle.success, custom_id="verify-button"
     )
     async def verify_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        assert isinstance(interaction.user, discord.Member)
+
+        if is_verified(interaction.user):
+            msg = await restore_verified_role(interaction)
+            await interaction.response.send_message(msg, ephemeral=True)
+            return
+
         await interaction.response.send_modal(EmailModal())
-
-
-def close_guild_db(guild: discord.Guild):
-    logging.info(f"closing guild db connection for {guild}")
-    gid = guild.id
-    conn = db_connections.pop(gid, None)
-    if conn:
-        conn.close()
 
 
 # ---------------- COMMANDS ----------------
@@ -402,7 +279,7 @@ def close_guild_db(guild: discord.Guild):
 async def export_db(interaction: discord.Interaction):
     await interaction.response.defer(ephemeral=True)
 
-    exported_csv = export_db_to_csv(get_guild_db(interaction.guild))  # type: ignore
+    exported_csv = export_db_to_csv(get_guild_db(interaction.guild))
 
     filename = (
         f"verification_backup_{interaction.guild.id}"  # type: ignore
@@ -426,12 +303,14 @@ async def export_db(interaction: discord.Interaction):
 @app_commands.guild_only()
 @logfire.instrument(extract_args=["interaction"])
 async def import_db(interaction: discord.Interaction, file: discord.Attachment):
+    assert interaction.guild is not None
+
     await interaction.response.defer(ephemeral=True)
 
-    conn = get_guild_db(interaction.guild)  # type: ignore
+    conn = get_guild_db(interaction.guild)
 
     try:
-        backup_dir = os.path.join(get_guild_dir(interaction.guild), "backups")  # type: ignore
+        backup_dir = os.path.join(get_guild_dir(interaction.guild), "backups")
         os.makedirs(backup_dir, exist_ok=True)
 
         timestamp = int(time.time())
@@ -588,7 +467,7 @@ async def check_setup(interaction: discord.Interaction):
 # Runs once on initial startup
 @bot.event
 async def setup_hook():
-    current_hash = get_commands_hash()
+    current_hash = get_commands_hash(bot.tree)
     stored_hash = None
     # Using hashes avoids unecessary syncing
     if os.path.exists("cmd_hash.txt"):
@@ -596,7 +475,7 @@ async def setup_hook():
             stored_hash = f.read().strip()
 
     if current_hash != stored_hash:
-        await tree.sync()
+        await bot.tree.sync()
         with open("cmd_hash.txt", "w") as f:
             f.write(current_hash)
         logging.info("Commands synced (hash changed)")

--- a/src/bot.py
+++ b/src/bot.py
@@ -40,7 +40,7 @@ pending_verifications = {}
 
 
 def is_verified(member: discord.Member) -> bool:
-    # Check DB if already verified
+    """Checks if a user is verified in the DB."""
     conn = get_guild_db(member.guild)
     c = conn.cursor()
     c.execute("SELECT verified, email FROM users WHERE discord_id=?", (member.id,))
@@ -48,12 +48,9 @@ def is_verified(member: discord.Member) -> bool:
     return row is not None and row[0] == 1
 
 
-async def grant_verified_role(interaction: discord.Interaction) -> str | None:
-    assert interaction.guild is not None
-    assert isinstance(interaction.user, discord.Member)
-
-    guild = interaction.guild
-    member = interaction.user
+async def grant_verified_role(member: discord.Member) -> str | None:
+    """Grants the verified role to a member. Returns an error message, or None on success."""
+    guild = member.guild
 
     role = get_verified_role(guild)
 
@@ -68,7 +65,7 @@ async def grant_verified_role(interaction: discord.Interaction) -> str | None:
     if role >= guild.me.top_role:
         await log_admin(
             "❌ Bot cannot assign role: it is higher than or equal to the bot's top role.",
-            interaction.guild,
+            guild,
         )
         return (
             "❌ Bot cannot assign the verified role because it is higher than"
@@ -85,18 +82,15 @@ async def grant_verified_role(interaction: discord.Interaction) -> str | None:
     return None
 
 
-async def restore_verified_role(interaction: discord.Interaction) -> str:
-    assert interaction.guild is not None
-    assert isinstance(interaction.user, discord.Member)
-
-    guild = interaction.guild
-    member = interaction.user
+async def restore_verified_role(member: discord.Member) -> str:
+    """Re-grants the verified role to a member. Returns a success/error message."""
+    guild = member.guild
     role = get_verified_role(guild)
 
     if not role:
         await log_admin(
             "❌ Bot is unable to check member roles",
-            interaction.guild,
+            guild,
         )
         return "⚠️ You are verified but I couldn't check roles."
 
@@ -105,8 +99,8 @@ async def restore_verified_role(interaction: discord.Interaction) -> str:
         return "✅ You are already verified."
 
     # Role missing - try to restore it
-    await log_admin(f"♻️ Restoring verified role for {interaction.user}", guild)
-    err = await grant_verified_role(interaction)
+    await log_admin(f"♻️ Restoring verified role for {member}", guild)
+    err = await grant_verified_role(member)
     if err is not None:
         return "🔁 You were already verified but I couldn't restore your role:\n" + err
     return "🔁 You were already verified - I've restored your role."
@@ -126,7 +120,7 @@ class EmailModal(discord.ui.Modal, title="Email Verification"):
         logging.info(f"{interaction.user} is attempting to verify")
 
         if is_verified(interaction.user):
-            msg = await restore_verified_role(interaction)
+            msg = await restore_verified_role(interaction.user)
             await interaction.response.send_message(msg, ephemeral=True)
             return
 
@@ -191,6 +185,7 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
     @logfire.instrument(extract_args=["interaction"])
     async def on_submit(self, interaction: discord.Interaction):
         assert interaction.guild is not None
+        assert isinstance(interaction.user, discord.Member)
 
         user_id = interaction.user.id
         key = (interaction.guild.id, user_id)
@@ -231,7 +226,7 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
         )
         conn.commit()
 
-        err = await grant_verified_role(interaction)
+        err = await grant_verified_role(interaction.user)
         if err is not None:
             await interaction.response.send_message(err, ephemeral=True)
             return
@@ -263,7 +258,7 @@ class VerifyButtonView(discord.ui.View):
         assert isinstance(interaction.user, discord.Member)
 
         if is_verified(interaction.user):
-            msg = await restore_verified_role(interaction)
+            msg = await restore_verified_role(interaction.user)
             await interaction.response.send_message(msg, ephemeral=True)
             return
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,10 +1,18 @@
+import hashlib
+import json
 import logging
 import os
+import sqlite3
+from functools import lru_cache
+from typing import TYPE_CHECKING
 
 import discord
 import logfire
 
 import config
+
+if TYPE_CHECKING:
+    from discord.app_commands import CommandTree
 
 
 def get_guild_dir(guild: discord.Guild):
@@ -24,6 +32,62 @@ def save_guild_info(guild: discord.Guild) -> None:
         f.write(guild.name)
 
 
+@lru_cache(maxsize=16)
+def get_guild_db(guild: discord.Guild):
+    path = get_guild_db_path(guild)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    conn = sqlite3.connect(path)
+    c = conn.cursor()
+    c.execute("""
+        CREATE TABLE IF NOT EXISTS users (
+            discord_id INTEGER PRIMARY KEY,
+            email TEXT,
+            verified INTEGER NOT NULL CHECK (verified IN (0, 1)) DEFAULT 0,
+            verified_at INTEGER CHECK (verified_at > 0),
+            CHECK ((verified_at IS NULL) OR verified) -- verified_at implies verified
+        ) STRICT
+    """)
+    c.execute("""
+        CREATE TABLE IF NOT EXISTS config (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        ) STRICT
+    """)
+    conn.commit()
+    logging.info(f"loaded or created database for guild {guild.id}")
+
+    save_guild_info(guild)
+
+    return conn
+
+
+def get_verified_role(guild: discord.Guild) -> discord.Role | None:
+    conn = get_guild_db(guild)
+    c = conn.cursor()
+    c.execute("SELECT value FROM config WHERE key = 'verified_role_id'")
+    row = c.fetchone()
+
+    if row is None:
+        return None
+
+    role_id = int(row[0])
+    return guild.get_role(role_id)
+
+
+def set_verified_role(guild: discord.Guild, role: discord.Role) -> None:
+    conn = get_guild_db(guild)
+    c = conn.cursor()
+    c.execute(
+        """
+        INSERT INTO config (key, value)
+        VALUES ('verified_role_id', ?)
+        ON CONFLICT(key) DO UPDATE SET value=excluded.value
+    """,
+        (str(role.id),),
+    )
+    conn.commit()
+
+
 async def log_admin(message, guild, **kwargs):
     logfire.debug(f'log_admin: logging "{message}" to guild {guild.id}')
 
@@ -38,3 +102,30 @@ async def log_admin(message, guild, **kwargs):
         return
 
     await channel.send(message, **kwargs)
+
+
+def get_commands_hash(tree: CommandTree) -> str:
+    # Changes when a commands name or description, or its parameters' name or description changes
+    # Also changes if a parameter's mandatoriness changes
+    commands = sorted(
+        (
+            {
+                "name": c.name,
+                "description": c.description,  # type: ignore
+                "parameters": sorted(
+                    (
+                        {
+                            "name": p.name,
+                            "description": p.description,
+                            "required": p.required,
+                        }
+                        for p in c.parameters  # type: ignore
+                    ),
+                    key=lambda p: p["name"],
+                ),
+            }
+            for c in tree.get_commands()
+        ),
+        key=lambda c: c["name"],
+    )
+    return hashlib.md5(json.dumps(commands, sort_keys=True).encode()).hexdigest()


### PR DESCRIPTION
This PR makes the following refactoring changes:
- Removes the unused `close_guild_db` function.
- Changes the `get_guild_db` function to use a `functools.lru_cache` instead of a diy cache.
- Moves some functions into `utils.py`
- Combines some duplicated logic for setting the verified role normally and restoring the verified role
- Reduces the number of `type: ignore` directives by using assertions instead

It also makes this change to functionality:
- When the `Verify Email` button is clicked, the bot now checks if the user is already verified (instead of only checking after the email is submitted).