### PR TITLE
Fix BotMissingPermissions error

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -348,7 +348,6 @@ async def import_db(interaction: discord.Interaction, file: discord.Attachment):
     description="Send a verification button to this channel",
 )
 @app_commands.default_permissions(administrator=True)
-@app_commands.checks.bot_has_permissions(send_messages=True)
 @app_commands.guild_only()
 @logfire.instrument()
 async def send_verify_button(interaction: discord.Interaction):


### PR DESCRIPTION
This condition is checked in the function body, and the additional decorator check is not handled. This PR fixes the issue by removing the decorator check.