### PR TITLE
Added verification stats tracking to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 # UNSW Discord Verification Bot
 
+![Verified Users](https://img.shields.io/badge/dynamic/json?url=https://gist.githubusercontent.com/secsocbot/6497aa02c3a8b313f04cb2abede84d98/raw/verifications.json&query=$.total&label=verified%20users&color=000000&style=for-the-badge&logo=discord)
+
 This is a simple and secure email-based verification bot for UNSW students and staff, hosted for free by the UNSW Security Society.
 It is designed to be as simple as possible to implement in any UNSW society as quickly as possible.
 See images of the verification process in `images` folder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "discord.py==2.6.4",
+    "httpx>=0.28.1",
     "logfire[system-metrics]>=4.32.1",
     "pydantic==2.12.5",
     "python-dotenv==1.2.1",

--- a/sample_env
+++ b/sample_env
@@ -15,3 +15,7 @@ MAILGUN_FROM=Verification Bot <verify@yourdomain.com>
 
 # Logfire (optional)
 LOGFIRE_TOKEN=
+
+# Stats tracking (optional)
+GITHUB_GIST_ID=YOUR_GIST_ID
+GITHUB_TOKEN=YOUR_PERSONAL_ACCESS_TOKEN

--- a/src/bot.py
+++ b/src/bot.py
@@ -14,6 +14,7 @@ import config
 import logs
 from export import export_db_to_csv, import_csv_to_db
 from otp import generate_otp, match_email, redact_email, send_email_otp, valid_email_domain
+from stats import increment_verification
 from utils import (
     get_commands_hash,
     get_guild_db,
@@ -279,6 +280,8 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
 
         await interaction.response.send_message("✅ Verification successful!", ephemeral=True)
         logging.info(f"verified user {interaction.user}")
+        if config.GIST_ID and config.GITHUB_TOKEN:
+            await increment_verification()
         await log_admin(
             f"✅ {interaction.user} verified with {redact_email(record['email'])}",
             interaction.guild,

--- a/src/bot.py
+++ b/src/bot.py
@@ -280,12 +280,12 @@ class OTPModal(discord.ui.Modal, title="Enter pin"):
 
         await interaction.response.send_message("✅ Verification successful!", ephemeral=True)
         logging.info(f"verified user {interaction.user}")
-        if config.GIST_ID and config.GITHUB_TOKEN:
-            await increment_verification()
         await log_admin(
             f"✅ {interaction.user} verified with {redact_email(record['email'])}",
             interaction.guild,
         )
+        if config.GIST_ID and config.GITHUB_TOKEN:
+            await increment_verification()
 
 
 class OTPView(discord.ui.View):

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,8 @@ MAILGUN_API_KEY = os.environ.get("MAILGUN_API_KEY")
 MAILGUN_DOMAIN = os.environ.get("MAILGUN_DOMAIN")
 MAILGUN_FROM = os.environ.get("MAILGUN_FROM")
 ALLOWED_DOMAINS = [d.strip().lower() for d in os.environ["ALLOWED_EMAIL_DOMAINS"].split(",")]
+GIST_ID = os.environ.get("GITHUB_GIST_ID")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 
 OTP_EXPIRY_SECONDS = 600
 OTP_RESEND_COOLDOWN = 120

--- a/src/stats.py
+++ b/src/stats.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -12,6 +13,8 @@ HEADERS = {
     "Authorization": f"Bearer {config.GITHUB_TOKEN}",
     "Accept": "application/vnd.github+json",
 }
+
+_lock = asyncio.Lock()
 
 
 class VerificationStats(BaseModel):
@@ -28,19 +31,23 @@ async def fetch_stats() -> VerificationStats:
 
 
 async def increment_verification() -> None:
-    try:
-        stats = await fetch_stats()
-        updated = VerificationStats(
-            total=stats.total + 1, last_verified=datetime.now(timezone.utc).isoformat()
-        )
-        async with httpx.AsyncClient() as client:
-            await client.patch(
-                GIST_API_URL,
-                headers=HEADERS,
-                json={
-                    "files": {"verifications.json": {"content": updated.model_dump_json(indent=2)}}
-                },
+    async with _lock:
+        try:
+            stats = await fetch_stats()
+            updated = VerificationStats(
+                total=stats.total + 1, last_verified=datetime.now(timezone.utc).isoformat()
             )
-        logging.info("Verification counter updated", extra={"total": updated.total})
-    except Exception as e:
-        logging.error("Failed to update verification gist", extra={"error": str(e)})
+            async with httpx.AsyncClient() as client:
+                await client.patch(
+                    GIST_API_URL,
+                    headers=HEADERS,
+                    json={
+                        "files": {"verifications.json": {
+                            "content": updated.model_dump_json(indent=2)
+                            }
+                        }
+                    },
+                )
+            logging.info("Verification counter updated", extra={"total": updated.total})
+        except Exception as e:
+            logging.error("Failed to update verification gist", extra={"error": str(e)})

--- a/src/stats.py
+++ b/src/stats.py
@@ -1,0 +1,46 @@
+import logging
+from datetime import datetime, timezone
+
+import httpx
+from pydantic import BaseModel
+
+import config
+
+GIST_API_URL = f"https://api.github.com/gists/{config.GIST_ID}"
+
+HEADERS = {
+    "Authorization": f"Bearer {config.GITHUB_TOKEN}",
+    "Accept": "application/vnd.github+json",
+}
+
+
+class VerificationStats(BaseModel):
+    total: int
+    last_verified: str | None
+
+
+async def fetch_stats() -> VerificationStats:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(GIST_API_URL, headers=HEADERS)
+        response.raise_for_status()
+        content = response.json()["files"]["verifications.json"]["content"]
+        return VerificationStats.model_validate_json(content)
+
+
+async def increment_verification() -> None:
+    try:
+        stats = await fetch_stats()
+        updated = VerificationStats(
+            total=stats.total + 1, last_verified=datetime.now(timezone.utc).isoformat()
+        )
+        async with httpx.AsyncClient() as client:
+            await client.patch(
+                GIST_API_URL,
+                headers=HEADERS,
+                json={
+                    "files": {"verifications.json": {"content": updated.model_dump_json(indent=2)}}
+                },
+            )
+        logging.info("Verification counter updated", extra={"total": updated.total})
+    except Exception as e:
+        logging.error("Failed to update verification gist", extra={"error": str(e)})

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,18 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -239,6 +251,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -747,6 +796,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "discord-py" },
+    { name = "httpx" },
     { name = "logfire", extra = ["system-metrics"] },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -763,6 +813,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "discord-py", specifier = "==2.6.4" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "logfire", extras = ["system-metrics"], specifier = ">=4.32.1" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "python-dotenv", specifier = "==1.2.1" },


### PR DESCRIPTION
Used secsoc bot account (from vaultwarden) for a public gist that is updated on each verification:

https://gist.github.com/secsocbot/6497aa02c3a8b313f04cb2abede84d98

This is then pulled usings shields.io to the readme.

Manually added conservative estimate of 500 verifications based on pydantic stats dashboard (I think it has been more than 30 days so we have lost some of the verif counting on there).